### PR TITLE
support for multiple client configs

### DIFF
--- a/force-authentication-core/src/main/java/net/davidbuccola/force/authentication/SignedRequestFilter.java
+++ b/force-authentication-core/src/main/java/net/davidbuccola/force/authentication/SignedRequestFilter.java
@@ -7,6 +7,7 @@ package net.davidbuccola.force.authentication;
 
 import canvas.CanvasRequest;
 import canvas.SignedRequest;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -20,10 +21,13 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A security filter that looks for authentication information in the form of a Salesforce canvas signed request passed
@@ -41,7 +45,7 @@ public class SignedRequestFilter extends GenericFilterBean {
         (GrantedAuthority) new SimpleGrantedAuthority("ROLE_CANVAS_USER")); // Indicate user came through an SFDC canvas
 
     @Autowired
-    private OAuthClientConfig clientConfig;
+    private Set<OAuthClientConfig> clientConfigs;
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
@@ -55,14 +59,25 @@ public class SignedRequestFilter extends GenericFilterBean {
                 logger.debug(String.format("Canvas '%s' detected", SIGNED_REQUEST));
             }
 
-            CanvasRequest canvasRequest;
-            try {
-                canvasRequest = SignedRequest.verifyAndDecode(signedRequest, clientConfig.getClientSecret());
-            } catch (SecurityException e) {
-                String message = "Signed request verification failed";
-                if (logger.isDebugEnabled()) {
-                    logger.debug(String.format("%s: signed_request=%s", message, signedRequest), e);
+            CanvasRequest canvasRequest = null;
+            OAuthClientConfig clientConfig = null;
+            String message = null;
+            Iterator<OAuthClientConfig> i = clientConfigs.iterator();
+            while(i.hasNext()) {
+                clientConfig = i.next();
+                try {
+                    // try to verify each clientConfig
+                    canvasRequest = SignedRequest.verifyAndDecode(signedRequest, clientConfig.getClientSecret());
+                } catch (SecurityException e) {
+                    message = "Signed request verification failed"+(i.hasNext() ? ", trying another.":"");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(String.format("%s: signed_request=%s", message, signedRequest), e);
+                    }
                 }
+            }
+
+            if (canvasRequest == null) {
+                // didn't find an OAuthClientConfig that passed verification
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, message);
                 return;
             }


### PR DESCRIPTION
Allows you to autowire a set of OAuthClientConfigs on the SignedRequestFilter. Each configuration is tried until either one is found that passes the request verification or they all fail. This way you can have   more than one Salesforce org using the same Canvas App, useful when you have a dev, uat, and prod org but only one separate system for the Canvas App. NOTE: only implemented on the SignedRequestFilter, I'd do it across the board but I'm under some time constraints.